### PR TITLE
Export css assets also from imports

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -91,8 +91,8 @@ final class Service
 		if (!$this->isEnabled()) {
 			$manifest = $this->getEndpointManifest($entrypoint);
 
-			foreach ( $manifest['css'] as $css) {
-				return $this->basePath . $css;
+			foreach ($manifest['css'] ?? [] as $css) {
+				yield $this->basePath . $css;
 			}
 
 			if ($withNestedCss) {

--- a/src/Service.php
+++ b/src/Service.php
@@ -59,6 +59,10 @@ final class Service
 		/** @var array<string, array<array<string, string>>> $manifest */
 		$manifest = $this->manifest[$entrypoint];
 
+		if ($manifest === null) {
+			throw new LogicalException('Invalid manifest');
+		}
+
 		return $manifest;
 	}
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -3,6 +3,7 @@
 namespace Contributte\Vite;
 
 use Contributte\Vite\Exception\LogicalException;
+use Generator;
 use Nette\Http\Request;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Html;
@@ -50,6 +51,17 @@ final class Service
 		$this->manifest = $manifest;
 	}
 
+	/**
+	 * @return array<string, array<array<string, string>>>
+	 */
+	private function getEndpointManifest(string $entrypoint): array {
+		$entrypoint = ltrim($entrypoint, '/');
+		/** @var array<string, array<array<string, string>>> $manifest */
+		$manifest = $this->manifest[$entrypoint];
+
+		return $manifest;
+	}
+
 	public function getAsset(string $entrypoint): string
 	{
 		if (str_starts_with($entrypoint, 'http')) {
@@ -60,28 +72,54 @@ final class Service
 			$baseUrl = $this->viteServer . '/';
 			$asset = $entrypoint;
 		} else {
-			$entrypoint = ltrim($entrypoint, '/');
 			$baseUrl = $this->basePath;
-			/** @var array<array<mixed>> $manifest */
-			$manifest = $this->manifest;
-			$asset = $manifest[$entrypoint]['file'] ?? throw new LogicalException('Invalid manifest');
+			$asset = $this->getEndpointManifest($entrypoint)['file'] ?? throw new LogicalException('Invalid manifest');
 		}
 
 		return $baseUrl . $asset;
 	}
 
 	/**
+	 * @return Generator<string>
+	 */
+	public function getCssAssets(string $entrypoint, bool $withNestedCss = false): Generator
+	{
+		if (!$this->isEnabled()) {
+			$manifest = $this->getEndpointManifest($entrypoint);
+			yield from $manifest['css'] ?? [];
+
+			if ($withNestedCss) {
+				$imports = $manifest['imports'] ?? [];
+				foreach ($imports as $import) {
+					yield from $this->getCssAssets($import, $withNestedCss);
+				}
+			}
+		}
+	}
+
+	/**
 	 * @return array<string, string>
 	 */
-	public function getCssAssets(string $entrypoint): array
+	public function getImports(string $entrypoint): array
 	{
 		$assets = [];
 
 		if (!$this->isEnabled()) {
-			$entrypoint = ltrim($entrypoint, '/');
-			/** @var array<string, array<array<string, string>>> $manifest */
-			$manifest = $this->manifest[$entrypoint];
-			$assets = $manifest[$entrypoint]['css'] ?? [];
+			$assets = $this->getEndpointManifest($entrypoint)['imports'] ?? [];
+		}
+
+		return $assets;
+	}
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function getDynamicImports(string $entrypoint): array
+	{
+		$assets = [];
+
+		if (!$this->isEnabled()) {
+			$assets = $this->getEndpointManifest($entrypoint)['dynamicImports'] ?? [];
 		}
 
 		return $assets;
@@ -92,21 +130,31 @@ final class Service
 		return $this->debugMode && $this->httpRequest->getCookie($this->viteCookie) === 'true';
 	}
 
-	public function printTags(string $entrypoint): void
+	/**
+	 * @return Generator<Html>
+	 */
+	public function getTags(string $entrypoint, bool $withNestedCss = false): Generator
 	{
 		$scripts = [$this->getAsset($entrypoint)];
-		$styles = $this->getCssAssets($entrypoint);
+		$styles = $this->getCssAssets($entrypoint, $withNestedCss);
 
 		if ($this->isEnabled()) {
-			echo Html::el('script')->type('module')->src($this->viteServer . '/@vite/client');
+			yield Html::el('script')->type('module')->src($this->viteServer . '/@vite/client');
 		}
 
 		foreach ($styles as $path) {
-			echo Html::el('link')->rel('stylesheet')->href($path);
+			yield Html::el('link')->rel('stylesheet')->href($path);
 		}
 
 		foreach ($scripts as $path) {
-			echo Html::el('script')->type('module')->src($path);
+			yield Html::el('script')->type('module')->src($path);
+		}
+	}
+
+	public function printTags(string $entrypoint, bool $withNestedCss = false): void
+	{
+		foreach ($this->getTags($entrypoint, $withNestedCss) as $tag) {
+			echo $tag;
 		}
 	}
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -90,7 +90,10 @@ final class Service
 	{
 		if (!$this->isEnabled()) {
 			$manifest = $this->getEndpointManifest($entrypoint);
-			yield from $manifest['css'] ?? [];
+
+			foreach ( $manifest['css'] as $css) {
+				return $this->basePath . $css;
+			}
 
 			if ($withNestedCss) {
 				$imports = $manifest['imports'] ?? [];


### PR DESCRIPTION
This PR exports css bundle of dependency (imports):

e.g
```json
[
  "scripts/gallery.mts": {
    "file": "assets/scripts/gallery-CbjZ6ab1.js",
    "name": "scripts/gallery",
    "src": "scripts/gallery.mts",
    "isEntry": true,
    "imports": [
      "_photoswipe-C2YEO2WN.js",
      "_pagination-BOokJuqp.js"
    ],
    "dynamicImports": [
      "node_modules/photoswipe/dist/photoswipe.esm.js"
    ]
  },
  "_photoswipe-C2YEO2WN.js": {
    "file": "assets/photoswipe-C2YEO2WN.js",
    "name": "photoswipe",
    "css": [
      "assets/photoswipe-DBYJbUcY.css"
    ]
  }
]
```

When you request `->getCssAssets("scripts/gallery.mts")`, it does not return `assets/photoswipe-DBYJbUcY.css` even it IMO should.