### PR TITLE
CI: inherit secrets for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,5 +14,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.3"


### PR DESCRIPTION
## What changed

- Enabled secret inheritance for the reusable coverage workflow.

## Why

The called reusable workflow can access required repository secrets during coverage reporting.

## Testing

- git diff --check